### PR TITLE
Updated heartbeat

### DIFF
--- a/services/bootstrapServices/everyBoot/setupStorage.js
+++ b/services/bootstrapServices/everyBoot/setupStorage.js
@@ -94,26 +94,26 @@ async function runInternal(config,firstTry) {
   if(drives.video) {
     var ok=prepDrive(drives.video,'Video',VIDEO_DIR,config.videoDriveEncryptionKey);
     if(!ok && drives.video.luksFormatted && !drives.video.luksOpened) {
-		// we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
-		ok=prepDrive(drives.video,'Video',VIDEO_DIR,config.buddyDriveEncryptionKey);
-		if(ok)debug("    Warning: Had to use buddy drive encryption key");
-	}
-	if(!ok) {
-	  debug("    Video drive failed to come online");
-	  drives.video=null;
-	}
+      // we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
+      ok=prepDrive(drives.video,'Video',VIDEO_DIR,config.buddyDriveEncryptionKey);
+      if(ok)debug("    Warning: Had to use buddy drive encryption key");
+    }
+    if(!ok) {
+      debug("    Video drive failed to come online");
+      drives.video=null;
+    }
   }
   if(drives.buddy) {
     var ok=prepDrive(drives.buddy,'Buddy',BUDDY_DIR,config.buddyDriveEncryptionKey);
     if(!ok && drives.buddy.luksFormatted && !drives.buddy.luksOpened) {
-		// we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
-		ok=prepDrive(drives.buddy,'Buddy',BUDDY_DIR,config.videoDriveEncryptionKey);
-		if(ok)debug("    Warning: Had to use video drive encryption key");
-	}
-	if(!ok) {
-	  debug("    Buddy drive failed to come online");
-	  drives.buddy=null;
-	}
+      // we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
+      ok=prepDrive(drives.buddy,'Buddy',BUDDY_DIR,config.videoDriveEncryptionKey);
+      if(ok)debug("    Warning: Had to use video drive encryption key");
+    }
+    if(!ok) {
+      debug("    Buddy drive failed to come online");
+      drives.buddy=null;
+    }
   }
 
   if(!drives.video && !drives.buddy) {
@@ -495,16 +495,18 @@ const _mount = async() => {
 }
 
 
-const writeHeartbeatData = async (data) {
+const writeHeartbeatData = async (data) => {
   if(data.video) {
-	delete data.video.luksPath; // possibly sensitive path (enc key)
+    delete data.video.luksName; // possibly sensitive path (enc key)
+    delete data.video.luksPath;
   }
   else {
     data.video={exists:false}; // null fields are sometimes weird in mongo, so ensure minimal data for each drive
   }
 
   if(data.buddy) {
-	delete data.buddy.luksPath;
+    delete data.buddy.luksName;
+    delete data.buddy.luksPath;
   }
   else {
     data.buddy={exists:false};

--- a/services/operationalServices/heartbeatService.js
+++ b/services/operationalServices/heartbeatService.js
@@ -26,7 +26,8 @@ async function run() {
         //TODO:
         //firewallHealthy: await firewallHealthy(),
         drivesHealthy: await drivesHealthy(),
-        videosAreRecording: await videosAreRecording()
+        videosAreRecording: await videosAreRecording(),
+        services:await getServiceData()
       }
     }
 
@@ -177,6 +178,55 @@ async function videosAreRecording() {
     tx2.issue(`Host: ${config.hostName} |  Cameras are not recording.`);
   }
   
+  return result;
+}
+
+async function getServiceData() {
+  // possible statuses in order: healthy, degraded, critical, emergency.
+  // overall status is the lowest of those seen
+  var result={status:"healthy"};
+
+  try {
+    var dir=await fs.readdir('/mnt/ramdisk/services');
+  }
+  catch(e) {
+    result.status="emergency";
+    result.reason="could not find services folder";
+    return result;
+  }
+
+  dir=dir.filter(o=>o.endsWith('.json')).sort();
+  var now=Date.now();
+  var allStatuses=[];
+
+  for(var file of dir) {
+    var service=file.slice(0,-5); // remove .json
+    try {
+      var dat=await fs.readFile(`/mnt/ramdisk/services/${file}`,"utf8");
+      dat=JSON.parse(dat);
+      if(dat.date < now - 15*60*1000) {
+        // if any data is over 15 minutes old, set that system to emergency, because it means something failed.
+        dat.status="emergency";
+      }
+      result[service]=dat;
+    }
+    catch(e) {
+      result[service]={
+        status:"emergency",
+        date:now,
+        reason:"could not read service file"
+      };
+    }
+    allStatuses.push(result[service].status);
+  }
+
+  if(allStatuses.includes("emergency"))
+    result.status="emergency";
+  else if(allStatuses.includes("critical"))
+    result.status="critical";
+  else if(allStatuses.includes("degraded"))
+    result.status="degraded";
+
   return result;
 }
 

--- a/services/operationalServices/heartbeatService.js
+++ b/services/operationalServices/heartbeatService.js
@@ -181,6 +181,23 @@ async function videosAreRecording() {
   return result;
 }
 
+
+/*
+  STATUS REPORTING
+  healthy   -- Everything appears functional. There might be minor misconfigurations or other small issues, but nothing that should affect stability.
+  degraded  -- Either something not-mission-critical is broken, or something mission-critical is working poorly. System is expected to still be stable, but it could use some attention when convenient.
+  critical  -- Something mission-critical is nonfunctional, and system may be unstable. It needs attention now, but will try to limp along for as long as it can.
+  emergency -- Something mission-critical is nonfunctional, and the system is **not** expected to be stable. It might limp along for a short period by chance, but it needs attention immediately.
+
+  The line between critical and emergency is pretty subtle, and either state should really be treated as a system failure.
+  Basically: critical means broken but probably will work for a while. emergency means broken and probably won't work at all, or if it does, it won't for long.
+
+  In short:
+  healthy   -- I'm fine
+  degraded  -- I need help, but it can probably wait til next week.
+  critical  -- I need help, but it can probably wait til tomorrow.
+  emergency -- I need help, ideally yesterday.
+*/
 async function getServiceData() {
   // possible statuses in order: healthy, degraded, critical, emergency.
   // overall status is the lowest of those seen

--- a/services/operationalServices/heartbeatService.js
+++ b/services/operationalServices/heartbeatService.js
@@ -187,7 +187,7 @@ async function getServiceData() {
   var result={status:"healthy"};
 
   try {
-    var dir=await fs.readdir('/mnt/ramdisk/services');
+    var dir=fs.readdirSync('/mnt/ramdisk/services');
   }
   catch(e) {
     result.status="emergency";
@@ -202,7 +202,7 @@ async function getServiceData() {
   for(var file of dir) {
     var service=file.slice(0,-5); // remove .json
     try {
-      var dat=await fs.readFile(`/mnt/ramdisk/services/${file}`,"utf8");
+      var dat=fs.readFileSync(`/mnt/ramdisk/services/${file}`,"utf8");
       dat=JSON.parse(dat);
       if(dat.date < now - 15*60*1000) {
         // if any data is over 15 minutes old, set that system to emergency, because it means something failed.


### PR DESCRIPTION
This adds an updated heartbeat system onto the existing heartbeat.

The heartbeat system now has a `services` object inside the `health` object. It populates this by reading every json file in `${ramdisk}/services/`. Each service is expected to include at a minimum a `date` (as a JS timestamp) and a status (one of "healthy", "degraded", "critical", and "emergency"). The heartbeat system sets the overall status (i.e. `health.services.status`) to the worst status it sees, and treats any statuses from over 15 minutes ago as "emergency" (since it means something probably died). Otherwise, the data in the json files is treated as an opaque chunk of data and included in the heartbeat for later analysis.  

Any service that wants to use the new system can just write a basic json file to `${ramdisk}/services/${name}.json` and it will be included automatically in every heartbeat. Minimum data is `{"status":"healthy","date":Date.now()}`. 

This PR also has setupStorage write all of its internal data to the new heartbeat system, as a simple proof of concept. (also included: better key sanitization of debug logs). This includes drive status, sizes, mount points, etc. It is probably more than is technically needed, but it is a good test to see what data is useful and what isn't.

Note: this PR should be merged after the one for trying both encryption keys, since I accidentally included that code too.