### PR TITLE
HW/SW monitoring in heartbeat data

### DIFF
--- a/services/bootstrapServices/bootstrapServices.js
+++ b/services/bootstrapServices/bootstrapServices.js
@@ -29,6 +29,7 @@ async function everyBoot() {
   await require("./everyBoot/setupRamDisk").run();
   await require("./everyBoot/cacheCameraConfig").run();
   await require("./everyBoot/setupStorage").run()
+  await require("./everyBoot/hwStatus").run()
   debug("Completed everyBoot Procedures");
 }
 

--- a/services/bootstrapServices/bootstrapServices.js
+++ b/services/bootstrapServices/bootstrapServices.js
@@ -30,6 +30,7 @@ async function everyBoot() {
   await require("./everyBoot/cacheCameraConfig").run();
   await require("./everyBoot/setupStorage").run()
   await require("./everyBoot/hwStatus").run()
+  await require("./everyBoot/swStatus").run()
   debug("Completed everyBoot Procedures");
 }
 

--- a/services/bootstrapServices/everyBoot/hwStatus.js
+++ b/services/bootstrapServices/everyBoot/hwStatus.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-const debug = require('debug')('setupStorage')
+const debug = require('debug')('hwStatus')
 debug.enabled = true
 const fs = require('fs')
 

--- a/services/bootstrapServices/everyBoot/hwStatus.js
+++ b/services/bootstrapServices/everyBoot/hwStatus.js
@@ -39,8 +39,6 @@ async function run() {
 }
 
 const writeHeartbeatData = async (data,config) => {
-  await execCommand(`mkdir -p ${RAM_DISK_BASE}/services`);
-
   fs.writeFileSync(`${RAM_DISK_BASE}/services/hwStatus.json`, sanitize(JSON.stringify(data)),'utf8');
 }
 

--- a/services/bootstrapServices/everyBoot/hwStatus.js
+++ b/services/bootstrapServices/everyBoot/hwStatus.js
@@ -31,14 +31,14 @@ const RAM_DISK_BASE="/mnt/ramdisk";
 
 async function run() {
   debug("Reading config...");
-  configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
+  var  configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
   config = JSON.parse(configString).config;
 
   var data=await getData()
-  await writeHeartbeatData(data,config);
+  writeHeartbeatData(data);
 }
 
-const writeHeartbeatData = async (data,config) => {
+const writeHeartbeatData = (data) => {
   fs.writeFileSync(`${RAM_DISK_BASE}/services/hwStatus.json`, sanitize(JSON.stringify(data)),'utf8');
 }
 

--- a/services/bootstrapServices/everyBoot/hwStatus.js
+++ b/services/bootstrapServices/everyBoot/hwStatus.js
@@ -1,0 +1,222 @@
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+const debug = require('debug')('setupStorage')
+debug.enabled = true
+const fs = require('fs')
+
+var config = {}
+
+function sanitize(str) {
+  str=str.replace(new RegExp(config.videoDriveEncryptionKey,"g"),"<video key>")
+  str=str.replace(new RegExp(config.buddyDriveEncryptionKey,"g"),"<buddy key>")
+  return str;
+}
+const execCommand = (command) => {
+  try {
+    return exec(command)
+  } catch(e) {
+    debug("COMMAND FAILED")
+    var cmd=command;
+    var str=e.stack||e.message||e;
+    var err=e.stderr;
+    debug(sanitize(cmd));
+    debug(sanitize(str));
+    debug(sanitize(err));
+    throw e;
+  }
+};
+
+const RAM_DISK_BASE="/mnt/ramdisk";
+
+async function run() {
+  debug("Reading config...");
+  configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
+  config = JSON.parse(configString).config;
+
+  var data=await getData()
+  await writeHeartbeatData(data,config);
+}
+
+const writeHeartbeatData = async (data,config) => {
+  await execCommand(`mkdir -p ${RAM_DISK_BASE}/services`);
+
+  fs.writeFileSync(`${RAM_DISK_BASE}/services/hwStatus.json`, sanitize(JSON.stringify(data)),'utf8');
+}
+
+
+
+// this system is for reporting only; for now it only can report healthy
+async function getData() {
+  return {
+    status:"healthy",
+    date:Date.now(),
+    uptime:await getUptimeData(),
+    disks:await getDFData(),
+    ram:await getFreeData(),
+    pi:await getVcgencmdData(),
+  }
+}
+
+async function getVcgencmdData() {
+  return {
+    temepratureC:await vcgencmdMeasureTemp(),
+    throttled:await vcgencmdGetThrottled(),
+    clock:{
+      cpu:await vcgencmdMeasureClock("arm"),
+      sdCard:await vcgencmdMeasureClock("emmc")
+    },
+    volts:{
+      core:await vcgencmdMeasureVolts("core"),
+      sdram_c:await vcgencmdMeasureVolts("sdram_c"),
+      sdram_i:await vcgencmdMeasureVolts("sdram_i"),
+      sdram_p:await vcgencmdMeasureVolts("sdram_p")
+    }
+  }
+}
+
+async function vcgencmdMeasureTemp() {
+  try {
+    var d=await execCommand(`vcgencmd measure_temp`);
+    d=d.stdout.trim().match(/^temp=([0-9]+\.[0-9]+)'C$/)
+    if(!d)return "N/A";
+    return parseFloat(d[1]);
+  }
+  catch(e) {
+    return e.message
+  }
+}
+async function vcgencmdGetThrottled() {
+  try {
+    var d=await execCommand(`vcgencmd get_throttled`);
+    d=d.stdout.trim().match(/^throttled=(0x[0-9a-fA-F]+)$/)
+    if(!d)return "N/A";
+    var numeric=parseInt(d[1],16);
+    return {
+      raw:numeric,
+      current:{
+        underVoltage: !!(numeric&(1<<0)),
+        armFreqCapped:!!(numeric&(1<<1)),
+        throttled:    !!(numeric&(1<<2)),
+        softTempLimit:!!(numeric&(1<<3))
+      },
+      occurred:{
+        underVoltage: !!(numeric&(1<<16)),
+        armFreqCapped:!!(numeric&(1<<17)),
+        throttled:    !!(numeric&(1<<18)),
+        softTempLimit:!!(numeric&(1<<19))
+      }
+    }
+
+  }
+  catch(e) {
+    return e.message;
+  }
+}
+async function vcgencmdMeasureClock(clock) {
+  try {
+    var d=await execCommand(`vcgencmd measure_clock ${clock}`);
+    d=d.stdout.trim().match(/^frequency\(.*\)=([0-9]+)$/)
+    if(!d)return "N/A";
+    return parseInt(d[1]);
+  }
+  catch(e) {
+    return e.message;
+  }
+}
+async function vcgencmdMeasureVolts(block) {
+  try {
+    var d=await execCommand(`vcgencmd measure_volts ${block}`);
+    d=d.stdout.trim().match(/^volt=([0-9]+\.[0-9]+)V$/)
+    if(!d)return "N/A";
+    return parseFloat(d[1]);
+  }
+  catch(e) {
+    return e.message;
+  }
+}
+
+
+async function getUptimeData() {
+  try {
+    var d=await execCommand(`uptime`)
+    d=d.stdout.trim().match(/^.*? up (.*?),  ([0-9]) user,  load average: ([0-9]+\.[0-9]+), ([0-9]+\.[0-9]+), ([0-9]+\.[0-9]+)$/);
+    if(!d)return "N/A"
+    return {
+      up:d[1],
+      users:parseInt(d[2]),
+      load:{
+        "1min":parseFloat(d[3]),
+        "5min":parseFloat(d[4]),
+        "15min":parseFloat(d[5])
+      }
+    }
+  }
+  catch(e) {
+    return e.message
+  }
+}
+
+async function getDFData() {
+  try {
+    var d=await execCommand(`df --output=target,size,used,avail --block-size=K`);
+    d=d.stdout.trim().split('\n');
+    d.shift() // remove header
+    d=d.map(l=>{
+      l=l.split(/\s+/);
+      var ret={
+        path:l[0],
+        size:parseInt(l[1]),
+        used:parseInt(l[2]),
+        avail:parseInt(l[3]),
+      }
+      ret.usedPercent=parseFloat((ret.used/ret.size*100).toFixed(3))
+      return ret;
+    });
+    return {
+      root:d.find(o=>o.path=='/')||"not found",
+      boot:d.find(o=>o.path=='/boot')||"not found",
+      video:d.find(o=>o.path=='/home/pi/videos')||"not found",
+      buddy:d.find(o=>o.path=='/home/pi/remote_backups')||"not found",
+      ramdisk:d.find(o=>o.path==RAM_DISK_BASE)||"not found",
+    }
+  }
+  catch(e) {
+    return e.message
+  }
+}
+
+function processFreeData(header,dat) {
+  var o={};
+  for(var i=1;i<dat.length;++i) {
+    var h=header[i-1];
+    o[h]=parseInt(dat[i])
+  }
+  if(o.available && o.total) {
+    o.usedPercent=parseFloat(((1-o.available/o.total)*100).toFixed(3))
+  }
+  else if(o.used && o.total) {
+    o.usedPercent=parseFloat((o.used/o.total*100).toFixed(3))
+  }
+  return o;
+}
+async function getFreeData() {
+  try {
+    var d=await execCommand(`free -wk`);
+    d=d.stdout.trim().split('\n');
+    var header=d[0].split(/\s+/)
+    var mem=d[1].split(/\s+/)
+    var swap=d[2].split(/\s+/)
+    return {
+      memory:processFreeData(header,mem),
+      swap:processFreeData(header,swap)
+    }
+  }
+  catch(e) {
+    return e.message
+  }
+}
+
+module.exports = {
+  run
+}

--- a/services/bootstrapServices/everyBoot/setupRamDisk.js
+++ b/services/bootstrapServices/everyBoot/setupRamDisk.js
@@ -43,6 +43,8 @@ async function run() {
     debug("Ram Disk mounted. Skipping");
   }
 
+  await exec(`mkdir -p /mnt/ramdisk/services`);
+
   debug("Completed Ram Disk Setup Procedure");
 }
 

--- a/services/bootstrapServices/everyBoot/setupStorage.js
+++ b/services/bootstrapServices/everyBoot/setupStorage.js
@@ -41,7 +41,7 @@ const RAM_DISK_BASE="/mnt/ramdisk";
 
 async function run() {
   debug("Reading config...");
-  configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
+  var configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
   config = JSON.parse(configString).config;
 
   try {
@@ -150,7 +150,7 @@ async function runInternal(config,firstTry) {
     }
   }
 
-  await writeHeartbeatData(heartbeatData,config);
+  writeHeartbeatData(heartbeatData);
   debug("Completed setting up drives");
 }
 
@@ -492,7 +492,7 @@ const _mount = async() => {
 }
 
 
-const writeHeartbeatData = async (data,config) => {
+const writeHeartbeatData = (data) => {
   if(!data.video) {
     data.video={exists:false}; // null fields are sometimes weird in mongo, so ensure minimal data for each drive
   }

--- a/services/bootstrapServices/everyBoot/setupStorage.js
+++ b/services/bootstrapServices/everyBoot/setupStorage.js
@@ -63,7 +63,7 @@ const prepDrive = async(driveSpec,driveName,mountPath,encryptionKey) => {
   debug(`  Setting up ${driveName.toLowerCase()} drive (${driveSpec.devicePath})...`)
   try {
     await bringDriveFullyOnline(driveSpec,mountPath,encryptionKey);
-    debug("    ${driveName} drive online");
+    debug(`    ${driveName} drive online`);
     return true;
   }
   catch(e) {

--- a/services/bootstrapServices/everyBoot/setupStorage.js
+++ b/services/bootstrapServices/everyBoot/setupStorage.js
@@ -501,7 +501,5 @@ const writeHeartbeatData = async (data,config) => {
     data.buddy={exists:false};
   }
 
-  await execCommand(`mkdir -p ${RAM_DISK_BASE}/services`);
-
   fs.writeFileSync(`${RAM_DISK_BASE}/services/setupStorage.json`, sanitize(JSON.stringify(data)),'utf8');
 }

--- a/services/bootstrapServices/everyBoot/setupStorage.js
+++ b/services/bootstrapServices/everyBoot/setupStorage.js
@@ -94,26 +94,26 @@ async function runInternal(config,firstTry) {
   if(drives.video) {
     var ok=prepDrive(drives.video,'Video',VIDEO_DIR,config.videoDriveEncryptionKey);
     if(!ok && drives.video.luksFormatted && !drives.video.luksOpened) {
-		// we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
-		ok=prepDrive(drives.video,'Video',VIDEO_DIR,config.buddyDriveEncryptionKey);
-		if(ok)debug("    Warning: Had to use buddy drive encryption key");
-	}
-	if(!ok) {
-	  debug("    Video drive failed to come online");
-	  drives.video=null;
-	}
+      // we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
+      ok=prepDrive(drives.video,'Video',VIDEO_DIR,config.buddyDriveEncryptionKey);
+      if(ok)debug("    Warning: Had to use buddy drive encryption key");
+    }
+    if(!ok) {
+      debug("    Video drive failed to come online");
+      drives.video=null;
+    }
   }
   if(drives.buddy) {
     var ok=prepDrive(drives.buddy,'Buddy',BUDDY_DIR,config.buddyDriveEncryptionKey);
     if(!ok && drives.buddy.luksFormatted && !drives.buddy.luksOpened) {
-		// we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
-		ok=prepDrive(drives.buddy,'Buddy',BUDDY_DIR,config.videoDriveEncryptionKey);
-		if(ok)debug("    Warning: Had to use video drive encryption key");
-	}
-	if(!ok) {
-	  debug("    Buddy drive failed to come online");
-	  drives.buddy=null;
-	}
+      // we saw a rare failure case where drives had the wrong encryption key used. So try the other just in case
+      ok=prepDrive(drives.buddy,'Buddy',BUDDY_DIR,config.videoDriveEncryptionKey);
+      if(ok)debug("    Warning: Had to use video drive encryption key");
+    }
+    if(!ok) {
+      debug("    Buddy drive failed to come online");
+      drives.buddy=null;
+    }
   }
 
   if(!drives.video && !drives.buddy) {
@@ -495,16 +495,18 @@ const _mount = async() => {
 }
 
 
-const writeHeartbeatData = async (data) {
+const writeHeartbeatData = async (data) => {
   if(data.video) {
-	delete data.video.luksPath; // possibly sensitive path (enc key)
+    delete data.video.luksName; // possibly sensitive path (enc key)
+    delete data.video.luksPath;
   }
   else {
     data.video={exists:false}; // null fields are sometimes weird in mongo, so ensure minimal data for each drive
   }
 
   if(data.buddy) {
-	delete data.buddy.luksPath;
+    delete data.buddy.luksName;
+    delete data.buddy.luksPath;
   }
   else {
     data.buddy={exists:false};

--- a/services/bootstrapServices/everyBoot/swStatus.js
+++ b/services/bootstrapServices/everyBoot/swStatus.js
@@ -1,0 +1,119 @@
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+const debug = require('debug')('setupStorage')
+debug.enabled = true
+const fs = require('fs')
+const pm2 = require('pm2')
+
+var config = {}
+
+function sanitize(str) {
+  str=str.replace(new RegExp(config.videoDriveEncryptionKey,"g"),"<video key>")
+  str=str.replace(new RegExp(config.buddyDriveEncryptionKey,"g"),"<buddy key>")
+  return str;
+}
+const execCommand = (command) => {
+  try {
+    return exec(command)
+  } catch(e) {
+    debug("COMMAND FAILED")
+    var cmd=command;
+    var str=e.stack||e.message||e;
+    var err=e.stderr;
+    debug(sanitize(cmd));
+    debug(sanitize(str));
+    debug(sanitize(err));
+    throw e;
+  }
+};
+
+const RAM_DISK_BASE="/mnt/ramdisk";
+
+async function run() {
+  debug("Reading config...");
+  configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
+  config = JSON.parse(configString).config;
+
+  var data=await getData()
+  await writeHeartbeatData(data,config);
+}
+
+const writeHeartbeatData = async (data,config) => {
+  await execCommand(`mkdir -p ${RAM_DISK_BASE}/services`);
+
+  fs.writeFileSync(`${RAM_DISK_BASE}/services/swStatus.json`, sanitize(JSON.stringify(data)),'utf8');
+}
+
+// this system will report emergency if any of the pm2 modules are not online
+async function getData() {
+  var dat={
+    status:"healthy",
+    date:Date.now(),
+    pm2:await getPM2Data(),
+    git:await getGitData()
+  }
+
+  for(var i=0;i<dat.pm2.length;i++) {
+    if(dat.pm2[i].status!='online')
+      dat.status='emergency'
+  }
+  return dat;
+}
+
+function processPM2Data(dat) {
+  return {
+    name:dat.name,
+    status:dat.pm2_env.status,
+    id:dat.pm_id,
+    pid:dat.pid,
+    restarts:dat.pm2_env.unstable_restarts,
+    uptimeHours:parseFloat(((Date.now()-dat.pm2_env.pm_uptime)/3600/1000).toFixed(2)),
+    memoryMB:dat.monit.memory/1024/1024,
+    cpu:dat.monit.cpu
+  }
+}
+async function getPM2Data() {
+  try {
+    var dat=await new Promise((resolve,reject)=>{
+      pm2.list((err,dat)=>{
+        if(err)reject(err);
+        resolve(dat);
+      });
+    });
+    dat=dat.map(processPM2Data)
+    dat.sort((a,b)=>a.id-b.id);
+    return dat;
+  }
+  catch(e) {
+    return e.message;
+  }
+  finally {
+  pm2.disconnect();
+  }
+}
+
+
+async function getGitData() {
+  try {
+    var d=await execCommand(`git status --porcelain -b`)
+    d=d.stdout.trim().split('\n')
+    var branch_line=d.shift();
+    var branch=branch_line.match(/^## (.*?)\.\.\./);
+    var ahead=branch_line.match(/ahead ([0-9]+)/);
+    var behind=branch_line.match(/behind ([0-9]+)/);
+    return {
+      branch:branch?branch[1]:'<unknown>',
+      ahead:ahead?parseInt(ahead[1]):0,
+      behind:behind?parseInt(behind[1]):0,
+      dirtyFiles:d.length
+    }
+  }
+  catch(e) {
+    return e.message;
+  }
+}
+
+module.exports = {
+  run
+}

--- a/services/bootstrapServices/everyBoot/swStatus.js
+++ b/services/bootstrapServices/everyBoot/swStatus.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-const debug = require('debug')('setupStorage')
+const debug = require('debug')('swStatus')
 debug.enabled = true
 const fs = require('fs')
 const pm2 = require('pm2')

--- a/services/bootstrapServices/everyBoot/swStatus.js
+++ b/services/bootstrapServices/everyBoot/swStatus.js
@@ -40,8 +40,6 @@ async function run() {
 }
 
 const writeHeartbeatData = async (data,config) => {
-  await execCommand(`mkdir -p ${RAM_DISK_BASE}/services`);
-
   fs.writeFileSync(`${RAM_DISK_BASE}/services/swStatus.json`, sanitize(JSON.stringify(data)),'utf8');
 }
 

--- a/services/bootstrapServices/everyBoot/swStatus.js
+++ b/services/bootstrapServices/everyBoot/swStatus.js
@@ -32,14 +32,14 @@ const RAM_DISK_BASE="/mnt/ramdisk";
 
 async function run() {
   debug("Reading config...");
-  configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
-  config = JSON.parse(configString).config;
+  var configString = fs.readFileSync(`${RAM_DISK_BASE}/config.json`, 'utf8');
+  config = JSON.parse(configString).config; // only needed for sanitize
 
   var data=await getData()
-  await writeHeartbeatData(data,config);
+  writeHeartbeatData(data);
 }
 
-const writeHeartbeatData = async (data,config) => {
+const writeHeartbeatData = (data) => {
   fs.writeFileSync(`${RAM_DISK_BASE}/services/swStatus.json`, sanitize(JSON.stringify(data)),'utf8');
 }
 

--- a/services/operationalServices/heartbeatService.js
+++ b/services/operationalServices/heartbeatService.js
@@ -26,7 +26,8 @@ async function run() {
         //TODO:
         //firewallHealthy: await firewallHealthy(),
         drivesHealthy: await drivesHealthy(),
-        videosAreRecording: await videosAreRecording()
+        videosAreRecording: await videosAreRecording(),
+        services:await getServiceData()
       }
     }
 
@@ -177,6 +178,55 @@ async function videosAreRecording() {
     tx2.issue(`Host: ${config.hostName} |  Cameras are not recording.`);
   }
   
+  return result;
+}
+
+async function getServiceData() {
+  // possible statuses in order: healthy, degraded, critical, emergency.
+  // overall status is the lowest of those seen
+  var result={status:"healthy"};
+
+  try {
+    var dir=await fs.readdir('/mnt/ramdisk/services');
+  }
+  catch(e) {
+    result.status="emergency";
+    result.reason="could not find services folder";
+    return result;
+  }
+
+  dir=dir.filter(o=>o.endsWith('.json')).sort();
+  var now=Date.now();
+  var allStatuses=[];
+
+  for(var file of dir) {
+    var service=file.slice(0,-5); // remove .json
+    try {
+      var dat=await fs.readFile(`/mnt/ramdisk/services/${file}`,"utf8");
+      dat=JSON.parse(dat);
+      if(dat.date < now - 15*60*1000) {
+        // if any data is over 15 minutes old, set that system to emergency, because it means something failed.
+        dat.status="emergency";
+      }
+      result[service]=dat;
+    }
+    catch(e) {
+      result[service]={
+        status:"emergency",
+        date:now,
+        reason:"could not read service file"
+      };
+    }
+    allStatuses.push(result[service].status);
+  }
+
+  if(allStatuses.includes("emergency"))
+    result.status="emergency";
+  else if(allStatuses.includes("critical"))
+    result.status="critical";
+  else if(allStatuses.includes("degraded"))
+    result.status="degraded";
+
   return result;
 }
 

--- a/services/operationalServices/heartbeatService.js
+++ b/services/operationalServices/heartbeatService.js
@@ -181,6 +181,23 @@ async function videosAreRecording() {
   return result;
 }
 
+
+/*
+  STATUS REPORTING
+  healthy   -- Everything appears functional. There might be minor misconfigurations or other small issues, but nothing that should affect stability.
+  degraded  -- Either something not-mission-critical is broken, or something mission-critical is working poorly. System is expected to still be stable, but it could use some attention when convenient.
+  critical  -- Something mission-critical is nonfunctional, and system may be unstable. It needs attention now, but will try to limp along for as long as it can.
+  emergency -- Something mission-critical is nonfunctional, and the system is **not** expected to be stable. It might limp along for a short period by chance, but it needs attention immediately.
+
+  The line between critical and emergency is pretty subtle, and either state should really be treated as a system failure.
+  Basically: critical means broken but probably will work for a while. emergency means broken and probably won't work at all, or if it does, it won't for long.
+
+  In short:
+  healthy   -- I'm fine
+  degraded  -- I need help, but it can probably wait til next week.
+  critical  -- I need help, but it can probably wait til tomorrow.
+  emergency -- I need help, ideally yesterday.
+*/
 async function getServiceData() {
   // possible statuses in order: healthy, degraded, critical, emergency.
   // overall status is the lowest of those seen

--- a/services/operationalServices/heartbeatService.js
+++ b/services/operationalServices/heartbeatService.js
@@ -187,7 +187,7 @@ async function getServiceData() {
   var result={status:"healthy"};
 
   try {
-    var dir=await fs.readdir('/mnt/ramdisk/services');
+    var dir=fs.readdirSync('/mnt/ramdisk/services');
   }
   catch(e) {
     result.status="emergency";
@@ -202,7 +202,7 @@ async function getServiceData() {
   for(var file of dir) {
     var service=file.slice(0,-5); // remove .json
     try {
-      var dat=await fs.readFile(`/mnt/ramdisk/services/${file}`,"utf8");
+      var dat=fs.readFileSync(`/mnt/ramdisk/services/${file}`,"utf8");
       dat=JSON.parse(dat);
       if(dat.date < now - 15*60*1000) {
         // if any data is over 15 minutes old, set that system to emergency, because it means something failed.


### PR DESCRIPTION
Adds a basic hw and sw monitoring modules (which monitor things like ram, pm2 status, drive status, etc) and wire them up to the heartbeat system. Also a few little cleanups here and there. The PM2 monitoring system will report emergency state if the expected pm2 jobs are not running.

This has been stable on 41 for several days. 